### PR TITLE
Fix the case when the key is the string representation of an integer

### DIFF
--- a/src/ApcuCache.php
+++ b/src/ApcuCache.php
@@ -51,7 +51,7 @@ class ApcuCache implements CacheInterface
         $keys = $this->iterableToArray($keys);
         $this->validateKeys($keys);
         $valuesFromCache = \apcu_fetch($keys, $success) ?: [];
-        $valuesFromCache = $this->normalizeAPCUoutput($valuesFromCache);
+        $valuesFromCache = $this->normalizeAPCuOutput($valuesFromCache);
         $values = array_fill_keys($keys, $default);
         foreach ($values as $key => $value) {
             $values[$key] = $valuesFromCache[(string)$key] ?? $value;
@@ -110,7 +110,7 @@ class ApcuCache implements CacheInterface
 
     /**
      * Converts iterable to array. If provided value is not iterable it throws an InvalidArgumentException
-     * @param $iterable
+     * @param mixed $iterable
      * @return array
      */
     private function iterableToArray($iterable): array
@@ -123,7 +123,7 @@ class ApcuCache implements CacheInterface
     }
 
     /**
-     * @param $key
+     * @param mixed $key
      */
     private function validateKey($key): void
     {
@@ -159,7 +159,7 @@ class ApcuCache implements CacheInterface
      * @param array $values
      * @return array
      */
-    private function normalizeAPCUoutput(array $values): array
+    private function normalizeAPCuOutput(array $values): array
     {
         $normalizedValues = [];
         foreach ($values as $key => $value) {

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yiisoft\Cache\Apcu;
+
+class InvalidArgumentException extends \RuntimeException implements \Psr\SimpleCache\InvalidArgumentException
+{
+}

--- a/tests/ApcuCacheTest.php
+++ b/tests/ApcuCacheTest.php
@@ -379,33 +379,4 @@ class ApcuCacheTest extends TestCase
         $cache = $this->createCacheInstance();
         $cache->has(1);
     }
-
-    /*public function testTest()
-    {
-        $store = \apcu_store('123', '321');
-        $fetch = \apcu_fetch('123', $success);
-        $this->assertSame('321', $fetch);
-
-        $valuesFromCache = \apcu_fetch(['123'], $successMultiple);
-        $values = $this->normalizeAPCUoutput($valuesFromCache);
-        $this->assertSame(['123' => '321'], $values);
-    }*/
-
-    /**
-     * Normalizes keys returned from apcu_fetch in multiple mode. If one of the keys is an integer (123) or a string
-     * representation of an integer ('123') the returned key from the cache doesn't equal neither to an integer nor a
-     * string ($key !== 123 and $key !== '123'). Coping element from the returned array one by one to the new array
-     * fixes this issue.
-     * @param array $values
-     * @return array
-     */
-    private function normalizeAPCUoutput(array $values): array
-    {
-        $normalizedValues = [];
-        foreach ($values as $key => $value) {
-            $normalizedValues[$key] = $value;
-        }
-
-        return $normalizedValues;
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -91,6 +91,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             'null' => ['test_null', null],
             'supported_key_characters' => ['AZaz09_.', 'b'],
             '64_characters_key_max' => ['bVGEIeslJXtDPrtK.hgo6HL25_.1BGmzo4VA25YKHveHh7v9tUP8r5BNCyLhx4zy', 'c'],
+            'string_with_number_key' => ['111', 11],
+            'string_with_number_key_1' => ['022', 22],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

Also added two methods `normalizeAPCUoutput()` and `splitValuesByKeyType()` due to weird behavior of APCu for multiple mode. `apcu_store` refuses to store values with int keys in multiple mode and `apcu_fetch` returns some weird keys for ints so that `$key !== 123` and `$key !== '123'` but `(string) $key === '123'`, maybe it adds some nonvisible character to such keys or something like that, haven't found any info about it.