### PR TITLE
Test: remove key normalization for ApcuCache::getMultiple()

### DIFF
--- a/src/ApcuCache.php
+++ b/src/ApcuCache.php
@@ -77,7 +77,7 @@ final class ApcuCache implements CacheInterface
             return $values;
         }
 
-        $valuesFromCache = $this->normalizeAPCuOutput($valuesFromCache);
+        //$valuesFromCache = $this->normalizeAPCuOutput($valuesFromCache);
 
         foreach ($values as $key => $value) {
             $values[$key] = $valuesFromCache[(string) $key] ?? $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
